### PR TITLE
Wire Part B search UI to Whoosh via Flask API

### DIFF
--- a/crawling/front_end/172_project/src/app/page.tsx
+++ b/crawling/front_end/172_project/src/app/page.tsx
@@ -1,12 +1,49 @@
 "use client";
-import { useState } from "react";
+
+import { FormEvent, useState } from "react";
 import Textbox from "@/components/textbox";
 import Button from "@/components/button";
 import Results from "@/components/results";
+import type { SearchHit } from "@/types/search";
+
+const SEARCH_API =
+  process.env.NEXT_PUBLIC_SEARCH_API_URL ?? "http://127.0.0.1:5001";
 
 export default function Home() {
   const [text, setText] = useState("");
-  const handleSubmit = () => {/*Use FastAPI or Flask to submit to searcher*/};
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [results, setResults] = useState<SearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const query = text.trim();
+    if (!query) {
+      return;
+    }
+
+    setSubmittedQuery(query);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({ q: query, limit: "10" });
+      const response = await fetch(`${SEARCH_API}/search?${params}`);
+      if (!response.ok) {
+        throw new Error(`Search failed (${response.status})`);
+      }
+      const data = (await response.json()) as { results: SearchHit[] };
+      setResults(data.results ?? []);
+    } catch {
+      setResults([]);
+      setError(
+        "Could not reach the search API. Start it with: cd crawling && python search_api.py",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="min-h-screen items-center my-10 bg-white">
@@ -15,9 +52,14 @@ export default function Home() {
         onSubmit={handleSubmit}
       >
         <Textbox value={text} onChange={setText} />
-        <Button disabled={text.trim().length === 0} />
+        <Button disabled={text.trim().length === 0 || loading} />
       </form>
-      <Results/>
+      <Results
+        results={results}
+        loading={loading}
+        error={error}
+        query={submittedQuery}
+      />
     </div>
   );
 }

--- a/crawling/front_end/172_project/src/components/results.tsx
+++ b/crawling/front_end/172_project/src/components/results.tsx
@@ -1,11 +1,59 @@
+import type { SearchHit } from "@/types/search";
 
+type ResultsProps = {
+  results: SearchHit[];
+  loading: boolean;
+  error: string | null;
+  query: string;
+};
 
-const Results = () => {
+const Results = ({ results, loading, error, query }: ResultsProps) => {
+  if (loading) {
+    return <p className="py-10 text-center text-gray-600">Searching…</p>;
+  }
+
+  if (error) {
+    return <p className="py-10 text-center text-red-600">{error}</p>;
+  }
+
+  if (!query.trim()) {
+    return null;
+  }
+
+  if (results.length === 0) {
     return (
-        <div className = "text-center py-10">
-            Results:
-        </div>
-    )
-}
+      <p className="py-10 text-center text-gray-600">
+        No results for &ldquo;{query}&rdquo;.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="mx-auto mt-8 max-w-3xl space-y-6 px-4">
+      {results.map((hit) => (
+        <li key={hit.url} className="border-b border-gray-200 pb-6">
+          <a
+            className="text-lg font-medium text-blue-700 hover:underline"
+            href={hit.url}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {hit.title || hit.url}
+          </a>
+          <p className="text-sm text-green-800">{hit.url}</p>
+          {hit.snippet ? (
+            <p
+              className="mt-2 text-sm text-gray-700"
+              dangerouslySetInnerHTML={{ __html: hit.snippet }}
+            />
+          ) : null}
+          <p className="mt-1 text-xs text-gray-500">
+            score: {hit.score.toFixed(4)}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+};
 
 export default Results;

--- a/crawling/front_end/172_project/src/types/search.ts
+++ b/crawling/front_end/172_project/src/types/search.ts
@@ -1,0 +1,11 @@
+export type SearchHit = {
+  url: string;
+  title: string;
+  score: number;
+  snippet: string;
+  outgoing_links: string[];
+};
+
+export type SearchResponse = {
+  results: SearchHit[];
+};

--- a/crawling/search.py
+++ b/crawling/search.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+
 from whoosh import index
 from whoosh.qparser import MultifieldParser
-from whoosh.query import Every
 
-INDEX_DIR = "whoosh_index_500mb"
+_BASE_DIR = Path(__file__).resolve().parent
+INDEX_DIR = str(_BASE_DIR / "whoosh_index_500mb")
 
 def search(query_text, limit=10):
     ind = index.open_dir(INDEX_DIR)

--- a/crawling/search_api.py
+++ b/crawling/search_api.py
@@ -1,0 +1,38 @@
+import os
+
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+from search import search
+
+DEFAULT_PORT = 5001
+
+app = Flask(__name__)
+CORS(
+    app,
+    resources={
+        r"/*": {
+            "origins": [
+                "http://localhost:3000",
+                "http://127.0.0.1:3000",
+            ]
+        }
+    },
+)
+
+
+@app.get("/health")
+def health():
+    return jsonify({"ok": True})
+
+
+@app.get("/search")
+def search_endpoint():
+    query = request.args.get("q", "")
+    limit = request.args.get("limit", default=10, type=int)
+    return jsonify({"results": search(query, limit=limit)})
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", DEFAULT_PORT))
+    app.run(host="127.0.0.1", port=port, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ beautifulsoup4==4.8.1
 
 #Indexing 
 whoosh==2.7.4
+
+# Search API for web UI
+flask==3.1.0
+flask-cors==5.0.1


### PR DESCRIPTION
- Add a Flask search API (`crawling/search_api.py`) that exposes Whoosh results at `GET /search?q=...` with CORS for the Next.js dev server.
- Connect the Part B frontend: form submit fetches results, shows loading/errors, and renders titles, URLs, highlighted snippets, and scores.
- Resolve `whoosh_index_500mb` relative to `crawling/search.py` so indexing and search work regardless of cwd.